### PR TITLE
fix: Remove required=False during session injection

### DIFF
--- a/mrgf/acapy.py
+++ b/mrgf/acapy.py
@@ -23,7 +23,7 @@ async def connection_to_principal(
         raise TypeError("connection must be connection id or ConnRecord")
 
     conn_record = cast(ConnRecord, conn_record)
-    framework = session.inject(GovernanceFramework, required=False)
+    framework = session.inject(GovernanceFramework)
     if not framework:
         raise NoLoadedFramework(
             "No machine readable governance framework found in context"

--- a/mrgf/acapy.py
+++ b/mrgf/acapy.py
@@ -23,7 +23,7 @@ async def connection_to_principal(
         raise TypeError("connection must be connection id or ConnRecord")
 
     conn_record = cast(ConnRecord, conn_record)
-    framework = session.inject(GovernanceFramework)
+    framework = session.inject_or(GovernanceFramework)
     if not framework:
         raise NoLoadedFramework(
             "No machine readable governance framework found in context"


### PR DESCRIPTION
During the merge of another component, it was discovered that
aries_cloudagent_python has removed the required flag in future commits.
To work around this, I have removed the flag from the injection call

Signed-off-by: Colton Wolkins (Indicio work address) <colton@indicio.tech>